### PR TITLE
Fixes for request body access and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Moesif API Elixir Plug enables your application to:
    ```elixir
    def deps do
      [
-       {:moesif_api, "~> 0.1.0"}
+       {:moesif_api, "~> 0.2.0"}
      ]
    end
    ```

--- a/lib/plug/cache_body_reader.ex
+++ b/lib/plug/cache_body_reader.ex
@@ -1,0 +1,11 @@
+defmodule MoesifApi.CacheBodyReader do
+  def read_body(conn, opts) do
+    config = MoesifApi.Config.fetch_config([])
+
+    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+    # Cache the body under the specified key in MoesisApi's config :raw_request_body_key, default is :raw_body
+    conn = put_in(conn.assigns[config[:raw_request_body_key]], body)
+
+    {:ok, body, conn}
+  end
+end

--- a/lib/plug/config.ex
+++ b/lib/plug/config.ex
@@ -11,7 +11,8 @@ defmodule MoesifApi.Config do
       application_id: "Your Moesif Application Id",
       event_queue_size: 100_000,
       max_batch_size: 100,
-      max_batch_wait_time_ms: 2_000
+      max_batch_wait_time_ms: 2_000,
+      raw_request_body_key: :raw_body,
     ]
   end
 end

--- a/lib/plug/event_batcher.ex
+++ b/lib/plug/event_batcher.ex
@@ -68,14 +68,14 @@ defmodule MoesifApi.EventBatcher do
   defp retry_post(url, body, headers, max_retries) do
     case HTTPoison.post(url, body, headers) do
       {:ok, %HTTPoison.Response{status_code: code, body: response_body}} when code in 400..599 ->
-        Logger.warn("Received #{code} response. Retrying... (#{max_retries} attempts left)")
+        Logger.warning("Received #{code} response. Retrying... (#{max_retries} attempts left)")
         handle_retry(url, body, headers, max_retries, response_body)
 
       {:ok, resp} ->
         Logger.info("Response from Moesif: #{inspect(resp)}")
 
-      {:error, _} = error ->
-        Logger.warn("Failed to send request due to client error. Retrying... (#{max_retries} attempts left)")
+      {:error, _} = _error ->
+        Logger.warning("Failed to send request due to client error. Retrying... (#{max_retries} attempts left)")
         handle_retry(url, body, headers, max_retries, "Client error")
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MoesifApi.MixProject do
   def project do
     [
       app: :moesif_api,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.14",
       deps: deps(),
       description: "The Moesif API Elixir Plug is a sophisticated API monitoring and analytics tool tailored for Elixir and Phoenix applications.",


### PR DESCRIPTION
Use CacheBodyReader to safely access raw body and handle non-json bodies with base64 encoding.  When using Parsers or otherwise needing to log the body and access the request body downstream of the MoesifApi Plug, a caching body reader can be  used with Parsers or is used in the MoesifApi plug automatically if not configured beforehand in a parser