### PR TITLE
Fix `skip` functionality and add customer Logger module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,20 @@ Check out the example application at https://github.com/Moesif/moesif-elixir-pho
       raw_request_body_key: :raw_body,
    ```
 
-3. If you are using Parsers, you need to use `MoesifApi.CacheBodyReader` to cache the request body. Add the following to your `endpoint.ex`:
+3. Add `MoesifApi.EventBatcher` in `application.ex` to handle event batching and sending to Moesif.
+
+  ```elixir
+  def start(...) do
+    children = [
+      ...,
+      MoesifApi.EventBatcher,
+      ...
+    ]
+    Supervisor.start_link(children, opts)
+  end
+  ```
+
+4. If you are using Parsers, you need to use `MoesifApi.CacheBodyReader` to cache the request body. Add the following to your `endpoint.ex`:
 
    ```elixir
    plug Plug.Parsers,
@@ -88,7 +101,7 @@ end
 - `get_session_token`: Function to extract session token from the request.
 - `get_metadata`: Function to extract metadata from the request.
 - `skip`: Function to skip logging if returns true.
-- `debug`: Boolean to indicate should log debug messages.
+- `debug`: Boolean to indicate should log debug messages. Default is `false`.
 
 ## Identifying Users and Companies
 

--- a/lib/logger.ex
+++ b/lib/logger.ex
@@ -1,0 +1,60 @@
+defmodule MoesifApi.Logger do
+  @moduledoc """
+  Custom logger for Moesif API that respects the debug configuration option.
+  """
+
+  require Logger
+
+  @doc """
+  Logs an info message if debug is enabled in the configuration.
+
+  ## Parameters
+  - message: The message to log
+  - metadata: Optional metadata to include with the log (default: [])
+  """
+  def info(message, metadata \\ []) do
+    if debug_enabled?() do
+      Logger.info("[Moesif] #{message}", metadata)
+    end
+  end
+
+  @doc """
+  Logs a debug message
+
+  ## Parameters
+  - message: The message to log
+  - metadata: Optional metadata to include with the log (default: [])
+  """
+  def debug(message, metadata \\ []) do
+    Logger.debug("[Moesif] #{message}", metadata)
+  end
+
+  @doc """
+  Logs a warning message
+
+  ## Parameters
+  - message: The message to log
+  - metadata: Optional metadata to include with the log (default: [])
+  """
+  def warning(message, metadata \\ []) do
+    Logger.warning("[Moesif] #{message}", metadata)
+  end
+
+  @doc """
+  Logs an error message
+
+  ## Parameters
+  - message: The message to log
+  - metadata: Optional metadata to include with the log (default: [])
+  """
+  def error(message, metadata \\ []) do
+    Logger.error("[Moesif] #{message}", metadata)
+  end
+
+  # Checks if debug logging is enabled in the configuration.
+  # Returns true if debug is enabled, false otherwise.
+  defp debug_enabled?() do
+    config = MoesifApi.Config.fetch_config()
+    config[:debug] == true
+  end
+end

--- a/lib/plug/cache_body_reader.ex
+++ b/lib/plug/cache_body_reader.ex
@@ -1,6 +1,6 @@
 defmodule MoesifApi.CacheBodyReader do
   def read_body(conn, opts) do
-    config = MoesifApi.Config.fetch_config([])
+    config = MoesifApi.Config.fetch_config()
 
     {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
     # Cache the body under the specified key in MoesisApi's config :raw_request_body_key, default is :raw_body

--- a/lib/plug/config.ex
+++ b/lib/plug/config.ex
@@ -1,5 +1,5 @@
 defmodule MoesifApi.Config do
-  def fetch_config(opts) do
+  def fetch_config(opts \\ []) do
     env_config = Application.get_env(:moesif_api, :config, [])
     with_defaults = Keyword.merge(default_config(), env_config)
     Keyword.merge(with_defaults, opts)
@@ -13,6 +13,7 @@ defmodule MoesifApi.Config do
       max_batch_size: 100,
       max_batch_wait_time_ms: 2_000,
       raw_request_body_key: :raw_body,
+      debug: false,
     ]
   end
 end

--- a/lib/plug/event_batcher.ex
+++ b/lib/plug/event_batcher.ex
@@ -1,6 +1,7 @@
 defmodule MoesifApi.EventBatcher do
   use GenServer
-  require Logger
+
+  alias MoesifApi.Logger
 
   def start_link(opts) do
     config = MoesifApi.Config.fetch_config(opts)
@@ -49,7 +50,6 @@ defmodule MoesifApi.EventBatcher do
   end
 
   def post_to_remote(batch, config) do
-    Logger.info("Remote URL: #{config[:api_url]} Application ID: #{config[:application_id]}")
     body = Jason.encode!(batch)
     Logger.info("Post Event Batch: #{body}")
     headers = [


### PR DESCRIPTION
Hello,

This PR includes a few changes, but I will list them here:

- Update README.md to include the `MoesifApi.EventBatcher` change for sending events to Moesif.
- Fixes the `skip` functionality because the existing code continues after checking if it should skip it.
- Related to `skip` functionality, now it does not continue sending the request to Moesif earlier than the current code, because there is no need to go further or show logs (when debug is enabled) if we want to skip it.
- Create a custom Moesif Logger, so we can only check the `debug` option in one place, and also, it appends `[Moesif] ` to any log logged by the library.

Let me know what you think or if you have any feedback, I'm always happy to improve.